### PR TITLE
NeutronInducedTrap fix - solver parameter assertion

### DIFF
--- a/festim/concentration/traps/neutron_induced_trap.py
+++ b/festim/concentration/traps/neutron_induced_trap.py
@@ -55,6 +55,7 @@ class NeutronInducedTrap(ExtrinsicTrapBase):
             A_0=A_0,
             E_A=E_A,
             id=id,
+            **kwargs,
         )
 
     def create_form_density(self, dx, dt, T):

--- a/festim/concentration/traps/neutron_induced_trap.py
+++ b/festim/concentration/traps/neutron_induced_trap.py
@@ -7,7 +7,7 @@ class NeutronInducedTrap(ExtrinsicTrapBase):
     Class for neutron induced trap creation with annealing.
     The temporal evolution of the trap density is given by
 
-    dn_t/dt = phi*K*(1 - n_t/n_max) + A_0*exp(-E_A/(k_B*T))*n_t
+    dn_t/dt = phi*K*(1 - n_t/n_max) - A_0*exp(-E_A/(k_B*T))*n_t
 
     Args:
         k_0 (float, list): trapping pre-exponential factor (m3 s-1)

--- a/test/unit/test_traps/test_neutron_induced_trap.py
+++ b/test/unit/test_traps/test_neutron_induced_trap.py
@@ -162,8 +162,7 @@ class TestNeutronInducedTrapSolverParameters:
 
     def test_attributes_change_since_instanciation(self):
         """
-        Test to ensure values can be updated from an original
-        instantation
+        Test to ensure values can be updated after instanciation
         """
 
         expected_tolerance= 3.6

--- a/test/unit/test_traps/test_neutron_induced_trap.py
+++ b/test/unit/test_traps/test_neutron_induced_trap.py
@@ -124,3 +124,38 @@ class TestNeutronInducedTrapVaryingTime:
         print(expected_form)
         print(self.my_trap.form_density)
         assert self.my_trap.form_density.equals(expected_form)
+
+
+class TestNeutronInducedTrapSolverParameters:
+    """
+    Test for NeutronInducedTrap class, with defined ExtrinsicTrapBase
+    solver parameters
+    """
+
+    my_trap = festim.NeutronInducedTrap(
+        1,
+        1,
+        1,
+        1,
+        "mat_name",
+        phi=1,
+        K=2,
+        n_max=3,
+        A_0=4,
+        E_A=5,
+        absolute_tolerance=2.5,
+        relative_tolerance=1.2e-10,
+        maximum_iterations=13,
+        linear_solver="mumps",
+    )
+
+    def test(self):
+        """
+        Tests how the solver paramters are assigned and ensures that
+        the default values have been updated
+        """
+
+        assert self.my_trap.absolute_tolerance == 2.5
+        assert self.my_trap.relative_tolerance == 1.2e-10
+        assert self.my_trap.maximum_iterations == 13
+        assert self.my_trap.linear_solver == "mumps"

--- a/test/unit/test_traps/test_neutron_induced_trap.py
+++ b/test/unit/test_traps/test_neutron_induced_trap.py
@@ -169,4 +169,4 @@ class TestNeutronInducedTrapSolverParameters:
         expected_tolerance= 3.6
         self.my_trap.absolute_tolerance = 3.6
 
-        assert self.my_trap.absolute_tolerance == expected_form
+        assert self.my_trap.absolute_tolerance == expected_tolerance

--- a/test/unit/test_traps/test_neutron_induced_trap.py
+++ b/test/unit/test_traps/test_neutron_induced_trap.py
@@ -149,7 +149,7 @@ class TestNeutronInducedTrapSolverParameters:
         linear_solver="mumps",
     )
 
-    def test(self):
+    def test_attributes_from_instanciation(self):
         """
         Tests how the solver paramters are assigned and ensures that
         the default values have been updated

--- a/test/unit/test_traps/test_neutron_induced_trap.py
+++ b/test/unit/test_traps/test_neutron_induced_trap.py
@@ -151,7 +151,7 @@ class TestNeutronInducedTrapSolverParameters:
 
     def test_attributes_from_instanciation(self):
         """
-        Tests how the solver paramters are assigned and ensures that
+        Tests the solver paramters are assigned and ensures that
         the default values have been updated
         """
 
@@ -159,3 +159,14 @@ class TestNeutronInducedTrapSolverParameters:
         assert self.my_trap.relative_tolerance == 1.2e-10
         assert self.my_trap.maximum_iterations == 13
         assert self.my_trap.linear_solver == "mumps"
+
+    def test_attributes_change_since_instanciation(self):
+        """
+        Test to ensure values can be updated from an original
+        instantation
+        """
+
+        expected_form = 3.6
+        self.my_trap.absolute_tolerance = 3.6
+
+        assert self.my_trap.absolute_tolerance == expected_form

--- a/test/unit/test_traps/test_neutron_induced_trap.py
+++ b/test/unit/test_traps/test_neutron_induced_trap.py
@@ -165,7 +165,7 @@ class TestNeutronInducedTrapSolverParameters:
         Test to ensure values can be updated after instanciation
         """
 
-        expected_tolerance= 3.6
+        expected_tolerance = 3.6
         self.my_trap.absolute_tolerance = 3.6
 
         assert self.my_trap.absolute_tolerance == expected_tolerance

--- a/test/unit/test_traps/test_neutron_induced_trap.py
+++ b/test/unit/test_traps/test_neutron_induced_trap.py
@@ -166,7 +166,7 @@ class TestNeutronInducedTrapSolverParameters:
         instantation
         """
 
-        expected_form = 3.6
+        expected_tolerance= 3.6
         self.my_trap.absolute_tolerance = 3.6
 
         assert self.my_trap.absolute_tolerance == expected_form


### PR DESCRIPTION
## Proposed changes

Solver parameters for NeutronInducedTrap traps could not assert new values for solver parameters from the defaults defined in ExtrinsicTrapBase. A simple example of this is shown below,  in which an ExtrinsicTrap is able to update the absolute tolerance from 1.0 to 2, whereas the NeutronInducedTrap does not.

Additionally a small typo in the doc strings is updated

```python
import festim as F

trap_extrinsic = F.ExtrinsicTrap(
    1,
    0,
    1,
    0,
    "mat_name",
    1,
    1,
    1,
    1,
    1,
    1,
    1,
    absolute_tolerance=2,
    relative_tolerance=3,
    maximum_iterations=4,
    linear_solver="example",
)
trap_neutron = F.NeutronInducedTrap(
    1,
    0,
    1,
    0,
    "mat_name",
    1,
    1,
    1,
    1,
    0,
    absolute_tolerance=5,
    relative_tolerance=6,
    maximum_iterations=7,
    linear_solver="example_2",
)
print(trap_extrinsic.absolute_tolerance)
print(trap_neutron.absolute_tolerance)

```

## Types of changes

by simply adding a
```python 
**kwargs
```
into the 
```python3
super().__init__()
```
for the NeutronInducedTrap, one can access the solver parameters

<!--Put an `x` in the boxes that apply-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [x] Documentation Update (if none of the other choices apply)
- [x] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] Black formatted
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
