### PR TITLE
Export to txt at all times and in steady state

### DIFF
--- a/festim/exports/txt_export.py
+++ b/festim/exports/txt_export.py
@@ -13,19 +13,25 @@ class TXTExport(festim.Export):
     Args:
         field (str): the exported field ("solute", "1", "retention",
             "T"...)
-        times (list): times of export. The stepsize will be modified to
-            ensure these timesteps are hit.
         label (str): label of the field. Will also be the filename.
         folder (str): the export folder
+        times (list, optional): if provided, the stepsize will be modified to
+            ensure these timesteps are exported. Otherwise exports at all
+            timesteps. Defaults to None.
     """
 
-    def __init__(self, field, times, label, folder) -> None:
+    def __init__(self, field, label, folder, times=None) -> None:
         super().__init__(field=field)
-        self.times = sorted(times)
+        if times:
+            self.times = sorted(times)
+        else:
+            self.times = times
         self.label = label
         self.folder = folder
 
     def is_it_time_to_export(self, current_time):
+        if self.times is None:
+            return True
         for time in self.times:
             if current_time == time:
                 return True
@@ -33,6 +39,8 @@ class TXTExport(festim.Export):
         return False
 
     def when_is_next_time(self, current_time):
+        if self.times is None:
+            return None
         for time in self.times:
             if current_time < time:
                 return time
@@ -74,4 +82,4 @@ class TXTExports:
         self.folder = folder
         self.exports = []
         for function, label in zip(self.fields, self.labels):
-            self.exports.append(TXTExport(function, times, label, folder))
+            self.exports.append(TXTExport(function, label, folder, times))

--- a/festim/exports/txt_export.py
+++ b/festim/exports/txt_export.py
@@ -53,7 +53,8 @@ class TXTExport(festim.Export):
         solution = f.project(self.function, V_DG1)
         if self.is_it_time_to_export(current_time):
             filename = "{}/{}_{}s.txt".format(self.folder, self.label, current_time)
-            busy = True
+            if dt is None:
+                filename = "{}/{}_steady.txt".format(self.folder, self.label)
             x = f.interpolate(f.Expression("x[0]", degree=1), V_DG1)
             # if the directory doesn't exist
             # create it

--- a/test/system/test_misc.py
+++ b/test/system/test_misc.py
@@ -142,3 +142,25 @@ def test_txt_export_all_times(tmp_path):
     assert os.path.exists(
         "{}/{}_{}s.txt".format(my_export.folder, my_export.label, 0.5)
     )
+
+
+def test_txt_export_steady_state(tmp_path):
+    """
+    Tests that TXTExport can be exported in steady state
+    """
+    my_model = F.Simulation()
+
+    my_model.mesh = F.MeshFromVertices(np.linspace(0, 1))
+    my_model.materials = F.Material(1, 1, 0)
+    my_model.settings = F.Settings(1e-10, 1e-10, transient=False)
+    my_model.T = F.Temperature(500)
+
+    my_export = F.TXTExport("solute", label="mobile_conc", folder=tmp_path)
+    my_model.exports = [my_export]
+
+    my_model.initialise()
+    my_model.run()
+
+    assert os.path.exists(
+        "{}/{}_steady.txt".format(my_export.folder, my_export.label)
+    )

--- a/test/system/test_misc.py
+++ b/test/system/test_misc.py
@@ -118,3 +118,21 @@ def test_wrong_value_for_bc_field(field):
     with pytest.raises(ValueError):
         sim.boundary_conditions = [F.BoundaryCondition(surfaces=1, field=field)]
         sim.initialise()
+
+
+def test_txt_export_all_times(tmp_path):
+    """
+    Tests that TXTExport can be exported at all timesteps
+    """
+    my_model = F.Simulation()
+
+    my_model.mesh = F.MeshFromVertices(np.linspace(0, 1))
+    my_model.materials = F.Material(1, 1, 0)
+    my_model.settings = F.Settings(1e-10, 1e-10, final_time=1)
+    my_model.T = F.Temperature(500)
+    my_model.dt = F.Stepsize(0.1)
+
+    my_model.exports = [F.TXTExport("solute", label="mobile_conc", folder=tmp_path)]
+
+    my_model.initialise()
+    my_model.run()

--- a/test/system/test_misc.py
+++ b/test/system/test_misc.py
@@ -1,6 +1,7 @@
 import festim as F
 import numpy as np
 import pytest
+import os
 
 
 def test_convective_flux():
@@ -132,7 +133,12 @@ def test_txt_export_all_times(tmp_path):
     my_model.T = F.Temperature(500)
     my_model.dt = F.Stepsize(0.1)
 
-    my_model.exports = [F.TXTExport("solute", label="mobile_conc", folder=tmp_path)]
+    my_export = F.TXTExport("solute", label="mobile_conc", folder=tmp_path)
+    my_model.exports = [my_export]
 
     my_model.initialise()
     my_model.run()
+
+    assert os.path.exists(
+        "{}/{}_{}s.txt".format(my_export.folder, my_export.label, 0.5)
+    )

--- a/test/system/test_misc.py
+++ b/test/system/test_misc.py
@@ -161,6 +161,4 @@ def test_txt_export_steady_state(tmp_path):
     my_model.initialise()
     my_model.run()
 
-    assert os.path.exists(
-        "{}/{}_steady.txt".format(my_export.folder, my_export.label)
-    )
+    assert os.path.exists("{}/{}_steady.txt".format(my_export.folder, my_export.label))

--- a/test/unit/test_exports/test_txt_export.py
+++ b/test/unit/test_exports/test_txt_export.py
@@ -25,7 +25,7 @@ class TestWrite:
     @pytest.fixture
     def my_export(self, tmpdir):
         d = tmpdir.mkdir("test_folder")
-        my_export = TXTExport("solute", [1, 2, 3], "solute_label", str(Path(d)))
+        my_export = TXTExport("solute", "solute_label", str(Path(d)), times=[1, 2, 3])
 
         return my_export
 
@@ -85,7 +85,7 @@ class TestIsItTimeToExport:
     @pytest.fixture
     def my_export(self, tmpdir):
         d = tmpdir.mkdir("test_folder")
-        my_export = TXTExport("solute", [1, 2, 3], "solute_label", str(Path(d)))
+        my_export = TXTExport("solute", "solute_label", str(Path(d)), times=[1, 2, 3])
 
         return my_export
 
@@ -105,7 +105,7 @@ class TestWhenIsNextTime:
     @pytest.fixture
     def my_export(self, tmpdir):
         d = tmpdir.mkdir("test_folder")
-        my_export = TXTExport("solute", [1, 2, 3], "solute_label", str(Path(d)))
+        my_export = TXTExport("solute", "solute_label", str(Path(d)), times=[1, 2, 3])
 
         return my_export
 


### PR DESCRIPTION
## Proposed changes

Fixes #546 and #509 

This PR modifies the `TXTExport` class so that users can export at all timesteps and in steady state.

The argument `times` is now optional and if not specified, the `TXTExport` will write the field to a txt file at all timesteps.
To this end we had to change the arguments order in the class instantiation so it may break things if users don't specify arguments names.

## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] Black formatted
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
