### PR TITLE
Fix final time overshoot

### DIFF
--- a/festim/generic_simulation.py
+++ b/festim/generic_simulation.py
@@ -301,7 +301,9 @@ class Simulation:
 
         #  Time-stepping
         print("Time stepping...")
-        while self.t < self.settings.final_time:
+        while self.t < self.settings.final_time and not np.isclose(
+            self.t, self.settings.final_time
+        ):
             self.iterate()
 
     def run_steady(self):
@@ -340,9 +342,7 @@ class Simulation:
 
         # avoid t > final_time
         next_time = self.t + float(self.dt.value)
-        if next_time > self.settings.final_time and not np.isclose(
-            self.t, self.settings.final_time
-        ):
+        if next_time > self.settings.final_time:
             self.dt.value.assign(self.settings.final_time - self.t)
 
     def display_time(self):

--- a/test/system/test_misc.py
+++ b/test/system/test_misc.py
@@ -162,3 +162,19 @@ def test_txt_export_steady_state(tmp_path):
     my_model.run()
 
     assert os.path.exists("{}/{}_steady.txt".format(my_export.folder, my_export.label))
+
+
+def test_finaltime_overshoot():
+    """Checks that the time doesn't overshoot the final time"""
+    my_model = F.Simulation()
+
+    my_model.mesh = F.MeshFromVertices(np.linspace(0, 1))
+    my_model.materials = F.Material(1, 1, 0)
+    my_model.settings = F.Settings(1e-10, 1e-10, final_time=1)
+    my_model.T = F.Temperature(500)
+    my_model.dt = F.Stepsize(0.1)
+
+    my_model.initialise()
+    my_model.run()
+
+    assert np.isclose(my_model.t, my_model.settings.final_time)


### PR DESCRIPTION
## Proposed changes

This is a patch to ensure the time doesn't over shoot the simulation final time.
Turns out #542 fixed the tiny stepsize issue but introduced an overshoot.

## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] Black formatted
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
