### PR TITLE
Patch derived quantities not exported at final timestep when stepsize is small

### DIFF
--- a/festim/exports/derived_quantities/derived_quantities.py
+++ b/festim/exports/derived_quantities/derived_quantities.py
@@ -123,7 +123,7 @@ class DerivedQuantities:
             nb_its_between_exports = self.nb_iterations_between_exports
             if nb_its_between_exports is None:
                 # export at the end
-                return t >= final_time
+                return np.isclose(t, final_time)
             else:
                 # export every N iterations
                 return nb_iterations % nb_its_between_exports == 0


### PR DESCRIPTION
## Proposed changes

This patch fixes #566 by modifying the way we check if the current timestep is the final time.

Thanks @nicolasialovega for helping finding the bug.

## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] Black formatted
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

