### PR TITLE
Tiny timestep

### DIFF
--- a/festim/generic_simulation.py
+++ b/festim/generic_simulation.py
@@ -351,7 +351,6 @@ class Simulation:
     def display_time(self):
         """Displays the current time"""
         simulation_percentage = round(self.t / self.settings.final_time * 100, 2)
-        simulation_time = round(self.t, 1) 
         elapsed_time = round(self.timer.elapsed()[0], 1)
         msg = "{:.1f} %        ".format(simulation_percentage)
         msg += "{:.1e} s".format(self.t)

--- a/festim/generic_simulation.py
+++ b/festim/generic_simulation.py
@@ -351,10 +351,10 @@ class Simulation:
     def display_time(self):
         """Displays the current time"""
         simulation_percentage = round(self.t / self.settings.final_time * 100, 2)
-        simulation_time = round(self.t, 1)
+        simulation_time = round(self.t, 1) 
         elapsed_time = round(self.timer.elapsed()[0], 1)
         msg = "{:.1f} %        ".format(simulation_percentage)
-        msg += "{:.1e} s".format(simulation_time)
+        msg += "{:.1e} s".format(self.t)
         msg += "    Ellapsed time so far: {:.1f} s".format(elapsed_time)
         if not np.isclose(self.t, self.settings.final_time) and self.log_level == 40:
             print(msg, end="\r")


### PR DESCRIPTION
## Proposed changes

When starting to solve a model, some initial stepsize can be required. Sometimes the adaptive timesteps becomes very small at the beginning of a simulation. In these cases, the message output in festim is 0.0 s. With this change, we can see tiny timesteps in the scientific format (eg 1E-9 s).
## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [ ] Black formatted
- [ ] Unit tests pass locally with my changes
- [X ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

