### PR TITLE
Support for XDMF export

### DIFF
--- a/festim/__init__.py
+++ b/festim/__init__.py
@@ -34,3 +34,4 @@ from .subdomain.surface_subdomain import SurfaceSubdomain1D
 from .subdomain.volume_subdomain import VolumeSubdomain1D
 
 from .exports.vtx import VTXExport
+from .exports.xdmf import XDMFExport

--- a/festim/exports/vtx.py
+++ b/festim/exports/vtx.py
@@ -65,14 +65,15 @@ class VTXExport:
 
         self._field = value
 
-    def define_writer(self, comm: mpi4py.MPI.Intracomm, functions: list) -> None:
+    def define_writer(self, comm: mpi4py.MPI.Intracomm) -> None:
         """Define the writer
 
         Args:
             comm (mpi4py.MPI.Intracomm): the MPI communicator
-            functions (list): the list of functions to export
         """
-        self.writer = VTXWriter(comm, self.filename, functions, "BP4")
+        self.writer = VTXWriter(
+            comm, self.filename, [field.solution for field in self.field], "BP4"
+        )
 
     def write(self, t: float):
         """Write functions to VTX file

--- a/festim/exports/xdmf.py
+++ b/festim/exports/xdmf.py
@@ -1,0 +1,74 @@
+import mpi4py
+from dolfinx.io import XDMFFile
+import festim as F
+
+
+class XDMFExport:
+    """Export functions to VTX file
+
+    Args:
+        filename (str): the name of the output file
+        field (int or festim.Species): the field index to export
+
+    Attributes:
+        filename (str): the name of the output file
+        writer (dolfinx.io.XDMFFile): the XDMF writer
+        field (festim.Species, list of festim.Species): the field index to export
+    """
+
+    def __init__(self, filename: str, field) -> None:
+        self.filename = filename
+        self.field = field
+
+    @property
+    def filename(self):
+        return self._filename
+
+    @filename.setter
+    def filename(self, value):
+        if not isinstance(value, str):
+            raise TypeError("filename must be of type str")
+        if not value.endswith(".xdmf"):
+            raise ValueError("filename must end with .xdmf")
+        self._filename = value
+
+    @property
+    def field(self):
+        return self._field
+
+    @field.setter
+    def field(self, value):
+        # check that field is festim.Species or list of festim.Species
+        if not isinstance(value, F.Species) and not isinstance(value, list):
+            raise TypeError(
+                "field must be of type festim.Species or list of festim.Species"
+            )
+        # check that all elements of list are festim.Species
+        if isinstance(value, list):
+            for element in value:
+                if not isinstance(element, F.Species):
+                    raise TypeError(
+                        "field must be of type festim.Species or list of festim.Species"
+                    )
+        # if field is festim.Species, convert to list
+        if not isinstance(value, list):
+            value = [value]
+
+        self._field = value
+
+    def define_writer(self, comm: mpi4py.MPI.Intracomm) -> None:
+        """Define the writer
+
+        Args:
+            comm (mpi4py.MPI.Intracomm): the MPI communicator
+        """
+        self.writer = XDMFFile(comm, self.filename, "w")
+
+    def write(self, t: float):
+        """Write functions to VTX file
+
+        Args:
+            t (float): the time of export
+        """
+        for field in self.field:
+            self.writer.write_function(field.solution, t)

--- a/festim/exports/xdmf.py
+++ b/festim/exports/xdmf.py
@@ -4,7 +4,7 @@ import festim as F
 
 
 class XDMFExport:
-    """Export functions to VTX file
+    """Export functions to XDMFfile
 
     Args:
         filename (str): the name of the output file

--- a/festim/hydrogen_transport_problem.py
+++ b/festim/hydrogen_transport_problem.py
@@ -127,7 +127,7 @@ class HydrogenTransportProblem:
             # TODO implement when export.field is an int or str
             # then find solution from index of species
 
-            if isinstance(export, F.VTXExport):
+            if isinstance(export, (F.VTXExport, F.XDMFExport)):
                 export.define_writer(MPI.COMM_WORLD)
 
     def define_function_space(self):

--- a/festim/hydrogen_transport_problem.py
+++ b/festim/hydrogen_transport_problem.py
@@ -128,9 +128,7 @@ class HydrogenTransportProblem:
             # then find solution from index of species
 
             if isinstance(export, F.VTXExport):
-                export.define_writer(
-                    MPI.COMM_WORLD, [field.solution for field in export.field]
-                )
+                export.define_writer(MPI.COMM_WORLD)
 
     def define_function_space(self):
         elements = ufl.FiniteElement("CG", self.mesh.mesh.ufl_cell(), 1)

--- a/festim/hydrogen_transport_problem.py
+++ b/festim/hydrogen_transport_problem.py
@@ -302,7 +302,7 @@ class HydrogenTransportProblem:
             times.append(float(self.t))
 
             for export in self.exports:
-                if isinstance(export, F.VTXExport):
+                if isinstance(export, (F.VTXExport, F.XDMFExport)):
                     export.write(float(self.t))
 
             # update previous solution

--- a/test/test_permeation_problem.py
+++ b/test/test_permeation_problem.py
@@ -33,6 +33,7 @@ def test_permeation_problem(mesh_size=1001):
             subdomain=left_surface, S_0=4.02e21, E_S=1.04, pressure=100, species="H"
         ),
     ]
+    my_model.exports = [F.XDMFExport("mobile_concentration.xdmf", field=mobile_H)]
 
     my_model.initialise()
 

--- a/test/test_vtx.py
+++ b/test/test_vtx.py
@@ -12,10 +12,11 @@ V = dolfinx.fem.FunctionSpace(mesh, ("Lagrange", 1))
 def test_vtx_export_one_function(tmpdir):
     """Test can add one function to a vtx export"""
     u = dolfinx.fem.Function(V)
-
+    sp = F.Species("H")
+    sp.solution = u
     filename = str(tmpdir.join("my_export.bp"))
-    my_export = F.VTXExport(filename, field=F.Species("H"))
-    my_export.define_writer(mesh.comm, [u])
+    my_export = F.VTXExport(filename, field=sp)
+    my_export.define_writer(mesh.comm)
 
     for t in range(10):
         u.interpolate(lambda x: t * (x[0] ** 2 + x[1] ** 2 + x[2] ** 2))
@@ -28,10 +29,14 @@ def test_vtx_export_two_functions(tmpdir):
     u = dolfinx.fem.Function(V)
     v = dolfinx.fem.Function(V)
 
+    sp1 = F.Species("1")
+    sp2 = F.Species("2")
+    sp1.solution = u
+    sp2.solution = v
     filename = str(tmpdir.join("my_export.bp"))
-    my_export = F.VTXExport(filename, field=[F.Species("1"), F.Species("2")])
+    my_export = F.VTXExport(filename, field=[sp1, sp2])
 
-    my_export.define_writer(mesh.comm, [u, v])
+    my_export.define_writer(mesh.comm)
 
     for t in range(10):
         u.interpolate(lambda x: t * (x[0] ** 2 + x[1] ** 2 + x[2] ** 2))

--- a/test/test_xdmf.py
+++ b/test/test_xdmf.py
@@ -14,10 +14,11 @@ def test_init():
     assert my_export.field == [species]
 
 
-def test_write():
+def test_write(tmp_path):
     """Tests the write method of XDMFExport creates a file"""
     species = F.Species("H")
-    my_export = F.XDMFExport(filename="my_export.xdmf", field=species)
+    filename = os.path.join(tmp_path, "test.xdmf")
+    my_export = F.XDMFExport(filename=filename, field=species)
 
     my_export.define_writer(MPI.COMM_WORLD)
 
@@ -30,10 +31,10 @@ def test_write():
     for t in [0, 1, 2, 3]:
         my_export.write(t=t)
 
-    assert os.path.exists("my_export.xdmf")
+    assert os.path.exists(filename)
 
 
-def test_integration_with_HTransportProblem():
+def test_integration_with_HTransportProblem(tmp_path):
     """Tests that XDMFExport can be used in conjunction with HTransportProblem"""
     my_model = F.HydrogenTransportProblem()
     my_model.mesh = F.Mesh1D(vertices=np.linspace(0, 1))
@@ -42,7 +43,7 @@ def test_integration_with_HTransportProblem():
     my_model.subdomains = [my_subdomain]
     my_model.temperature = 500.0
     my_model.species = [F.Species("H")]
-    filename = "my_export.xdmf"
+    filename = os.path.join(tmp_path, "test.xdmf")
     my_model.exports = [F.XDMFExport(filename=filename, field=my_model.species)]
 
     my_model.initialise()

--- a/test/test_xdmf.py
+++ b/test/test_xdmf.py
@@ -1,0 +1,52 @@
+import festim as F
+from dolfinx import fem, mesh
+import mpi4py.MPI as MPI
+import os
+import numpy as np
+
+
+def test_init():
+    """Tests the initialisation of XDMFExport"""
+    species = F.Species("H")
+    my_export = F.XDMFExport(filename="my_export.xdmf", field=species)
+
+    assert my_export.filename == "my_export.xdmf"
+    assert my_export.field == [species]
+
+
+def test_write():
+    """Tests the write method of XDMFExport creates a file"""
+    species = F.Species("H")
+    my_export = F.XDMFExport(filename="my_export.xdmf", field=species)
+
+    my_export.define_writer(MPI.COMM_WORLD)
+
+    domain = mesh.create_unit_cube(MPI.COMM_WORLD, 10, 10, 10)
+    V = fem.FunctionSpace(domain, ("Lagrange", 1))
+    u = fem.Function(V)
+
+    species.solution = u
+
+    for t in [0, 1, 2, 3]:
+        my_export.write(t=t)
+
+    assert os.path.exists("my_export.xdmf")
+
+
+def test_integration_with_HTransportProblem():
+    """Tests that XDMFExport can be used in conjunction with HTransportProblem"""
+    my_model = F.HydrogenTransportProblem()
+    my_model.mesh = F.Mesh1D(vertices=np.linspace(0, 1))
+    my_mat = F.Material(D_0=1.9e-7, E_D=0.2, name="my_mat")
+    my_subdomain = F.VolumeSubdomain1D(id=1, borders=[0, 1], material=my_mat)
+    my_model.subdomains = [my_subdomain]
+    my_model.temperature = 500.0
+    my_model.species = [F.Species("H")]
+    filename = "my_export.xdmf"
+    my_model.exports = [F.XDMFExport(filename=filename, field=my_model.species)]
+
+    my_model.initialise()
+    my_model.run(1)
+
+    # checks that filename exists
+    assert os.path.exists(filename)

--- a/test/test_xdmf.py
+++ b/test/test_xdmf.py
@@ -3,6 +3,7 @@ from dolfinx import fem, mesh
 import mpi4py.MPI as MPI
 import os
 import numpy as np
+import pytest
 
 
 def test_init():
@@ -51,3 +52,31 @@ def test_integration_with_HTransportProblem(tmp_path):
 
     # checks that filename exists
     assert os.path.exists(filename)
+
+
+def test_field_attribute_is_always_list():
+    """Test that the field attribute is always a list"""
+    my_export = F.XDMFExport("my_export.xdmf", field=F.Species("H"))
+    assert isinstance(my_export.field, list)
+
+    my_export = F.XDMFExport("my_export.xdmf", field=[F.Species("H")])
+    assert isinstance(my_export.field, list)
+
+
+@pytest.mark.parametrize("field", ["H", 1, [F.Species("H"), 1]])
+def test_field_attribute_raises_error_when_invalid_type(field):
+    """Test that the field attribute raises an error if the type is not festim.Species or list"""
+    with pytest.raises(TypeError):
+        F.XDMFExport("my_export.xdmf", field=field)
+
+
+def test_filename_raises_error_with_wrong_extension():
+    """Test that the filename attribute raises an error if the extension is not .xdmf"""
+    with pytest.raises(ValueError):
+        F.XDMFExport("my_export.txt", field=[F.Species("H")])
+
+
+def test_filename_raises_error_when_wrong_type():
+    """Test that the filename attribute raises an error if the file is not str"""
+    with pytest.raises(TypeError):
+        F.XDMFExport(1, field=[F.Species("H")])


### PR DESCRIPTION
## Proposed changes

This PR adds a class to support XDMF export.

The XDMF format isn't maintained anymore so we may end up dropping support for it one day, but for now this is still a very valid option for exporting CG type functions.

**Usage**

```python
    my_model = F.HydrogenTransportProblem()
    my_model.mesh = F.Mesh1D(vertices=np.linspace(0, 1))
    my_mat = F.Material(D_0=1.9e-7, E_D=0.2, name="my_mat")
    my_subdomain = F.VolumeSubdomain1D(id=1, borders=[0, 1], material=my_mat)
    my_model.subdomains = [my_subdomain]
    my_model.temperature = 500.0
    my_model.species = [F.Species("H")]

    my_model.exports = [F.XDMFExport(filename="test.xdmf", field=my_model.species)]

    my_model.initialise()
    my_model.run(1)
```

Other:
- slight refactoring of the VTX define

## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] Black formatted
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
