### PR TITLE
Fix ufl cell vs basix cell

### DIFF
--- a/festim/hydrogen_transport_problem.py
+++ b/festim/hydrogen_transport_problem.py
@@ -1,6 +1,7 @@
 from dolfinx import fem
 from dolfinx.nls.petsc import NewtonSolver
 from dolfinx.io import XDMFFile
+import basix
 import ufl
 from mpi4py import MPI
 from dolfinx.fem import Function, form, assemble_scalar
@@ -133,7 +134,12 @@ class HydrogenTransportProblem:
                     export.writer.write_mesh(self.mesh.mesh)
 
     def define_function_space(self):
-        elements = ufl.FiniteElement("CG", self.mesh.mesh.ufl_cell(), 1)
+        elements = basix.ufl.element(
+            basix.ElementFamily.P,
+            self.mesh.mesh.basix_cell(),
+            1,
+            basix.LagrangeVariant.equispaced,
+        )
         self.function_space = fem.FunctionSpace(self.mesh.mesh, elements)
 
     def define_markers_and_measures(self):

--- a/test/benchmark.py
+++ b/test/benchmark.py
@@ -17,18 +17,16 @@ from dolfinx.fem.petsc import (
 from dolfinx.nls.petsc import NewtonSolver
 from ufl import (
     dot,
-    FiniteElement,
     grad,
     TestFunction,
     exp,
     FacetNormal,
-    dx,
-    ds,
     Cell,
     Mesh,
     VectorElement,
     Measure,
 )
+import basix
 from dolfinx.mesh import create_mesh, meshtags, locate_entities
 import numpy as np
 import tqdm.autonotebook
@@ -50,7 +48,12 @@ def fenics_test_permeation_problem(mesh_size=1001):
     vdim = my_mesh.topology.dim
     n = FacetNormal(my_mesh)
 
-    elements = FiniteElement("CG", my_mesh.ufl_cell(), 1)
+    elements = basix.ufl.element(
+        basix.ElementFamily.P,
+        my_mesh.basix_cell(),
+        1,
+        basix.LagrangeVariant.equispaced,
+    )
     V = FunctionSpace(my_mesh, elements)
     u = Function(V)
     u_n = Function(V)

--- a/test/test_permeation_problem.py
+++ b/test/test_permeation_problem.py
@@ -75,11 +75,12 @@ def test_permeation_problem(mesh_size=1001):
     analytical_flux = np.abs(analytical_flux)
     flux_values = np.array(np.abs(flux_values))
 
+    indices = np.where(analytical_flux > 0.01 * np.max(analytical_flux))
+    analytical_flux = analytical_flux[indices]
+    flux_values = flux_values[indices]
+
     relative_error = np.abs((flux_values - analytical_flux) / analytical_flux)
 
-    relative_error = relative_error[
-        np.where(analytical_flux > 0.01 * np.max(analytical_flux))
-    ]
     error = relative_error.mean()
 
     assert error < 0.01
@@ -165,11 +166,12 @@ def test_permeation_problem_multi_volume():
     analytical_flux = np.abs(analytical_flux)
     flux_values = np.array(np.abs(flux_values))
 
+    indices = np.where(analytical_flux > 0.01 * np.max(analytical_flux))
+    analytical_flux = analytical_flux[indices]
+    flux_values = flux_values[indices]
+
     relative_error = np.abs((flux_values - analytical_flux) / analytical_flux)
 
-    relative_error = relative_error[
-        np.where(analytical_flux > 0.01 * np.max(analytical_flux))
-    ]
     error = relative_error.mean()
 
     assert error < 0.01


### PR DESCRIPTION
## Proposed changes

This is a small PR to anticipate the future deprecation of `ufl.FiniteElement` and uses basix instead.
Also modifies the permeation test to avoid dividing by zero.

Overall reduces the number of warnings in the tests.
