### PR TITLE
Fix vtx outputs zero

### DIFF
--- a/festim/hydrogen_transport_problem.py
+++ b/festim/hydrogen_transport_problem.py
@@ -285,7 +285,7 @@ class HydrogenTransportProblem:
 
             for idx, spe in enumerate(self.species):
                 spe.sub_function_space = self.function_space.sub(idx)
-                spe.post_processing_solution = self.u.sub(idx).collapse()
+                spe.post_processing_solution = self.u.sub(idx)
                 spe.collapsed_function_space, _ = self.function_space.sub(
                     idx
                 ).collapse()

--- a/festim/hydrogen_transport_problem.py
+++ b/festim/hydrogen_transport_problem.py
@@ -277,7 +277,7 @@ class HydrogenTransportProblem:
             sub_prev_solution = [self.u_n]
             sub_test_functions = [ufl.TestFunction(self.function_space)]
             self.species[0].sub_function_space = self.function_space
-            self.species[0].post_processing_solution = fem.Function(self.function_space)
+            self.species[0].post_processing_solution = self.u
         else:
             sub_solutions = list(ufl.split(self.u))
             sub_prev_solution = list(ufl.split(self.u_n))
@@ -498,16 +498,11 @@ class HydrogenTransportProblem:
                     self.mesh.mesh, self.temperature_fenics, self.species[0]
                 )
                 cm = self.u
-                self.species[0].post_processing_solution = self.u
-
                 surface_flux = form(D_D * dot(grad(cm), self.mesh.n) * self.ds(2))
                 flux = assemble_scalar(surface_flux)
                 self.flux_values.append(flux)
                 self.times.append(float(self.t))
             else:
-                for idx, spe in enumerate(self.species):
-                    spe.post_processing_solution = self.u.sub(idx)
-
                 cm_1, cm_2 = self.u.split()
                 D_1 = self.subdomains[0].material.get_diffusion_coefficient(
                     self.mesh.mesh, self.temperature_fenics, self.species[0]


### PR DESCRIPTION
## Proposed changes

This PR fixes #622

Turns out using `.collapse()` for the output function of a `VTXWriter` produces zeros when writing. This doesn't occur with `XDMFFile`.

I removed it and manually tested that the expected output was produced.
I cannot add test for this as dolfinx doesn't have checkpointing yet.

Also removed some un-necessary code here and there.

## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] Black formatted
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
