### PR TITLE
Better error message when users use conditional for functions of t only

### DIFF
--- a/festim/boundary_conditions/dirichlet_bc.py
+++ b/festim/boundary_conditions/dirichlet_bc.py
@@ -1,5 +1,6 @@
 import festim as F
 import ufl
+from ufl.core.operator import Operator
 from dolfinx import fem
 import numpy as np
 
@@ -98,6 +99,8 @@ class DirichletBC:
 
             if "t" in arguments and "x" not in arguments and "T" not in arguments:
                 # only t is an argument
+                if isinstance(self.value(t=float(t)), Operator):
+                    raise ValueError("wrong type for temperature")
                 self.value_fenics = F.as_fenics_constant(
                     mesh=mesh, value=self.value(t=float(t))
                 )

--- a/festim/boundary_conditions/dirichlet_bc.py
+++ b/festim/boundary_conditions/dirichlet_bc.py
@@ -1,6 +1,5 @@
 import festim as F
 import ufl
-from ufl.core.operator import Operator
 from dolfinx import fem
 import numpy as np
 

--- a/festim/boundary_conditions/dirichlet_bc.py
+++ b/festim/boundary_conditions/dirichlet_bc.py
@@ -99,8 +99,10 @@ class DirichletBC:
 
             if "t" in arguments and "x" not in arguments and "T" not in arguments:
                 # only t is an argument
-                if isinstance(self.value(t=float(t)), Operator):
-                    raise ValueError("wrong type for temperature")
+                if not isinstance(self.value(t=float(t)), (float, int)):
+                    raise ValueError(
+                        f"self.value should return a float or an int, not {type(self.value(t=float(t)))} "
+                    )
                 self.value_fenics = F.as_fenics_constant(
                     mesh=mesh, value=self.value(t=float(t))
                 )

--- a/festim/hydrogen_transport_problem.py
+++ b/festim/hydrogen_transport_problem.py
@@ -3,6 +3,7 @@ from dolfinx.nls.petsc import NewtonSolver
 from dolfinx.io import XDMFFile
 import basix
 import ufl
+from ufl.core.operator import Operator
 from mpi4py import MPI
 from dolfinx.fem import Function, form, assemble_scalar
 from dolfinx.mesh import meshtags
@@ -196,6 +197,8 @@ class HydrogenTransportProblem:
         elif callable(self.temperature):
             arguments = self.temperature.__code__.co_varnames
             if "t" in arguments and "x" not in arguments and "T" not in arguments:
+                if isinstance(self.temperature(t=float(self.t)), Operator):
+                    raise ValueError("wrong type for temperature")
                 # only t is an argument
                 self.temperature_fenics = F.as_fenics_constant(
                     mesh=self.mesh.mesh, value=self.temperature(t=float(self.t))

--- a/festim/hydrogen_transport_problem.py
+++ b/festim/hydrogen_transport_problem.py
@@ -195,7 +195,7 @@ class HydrogenTransportProblem:
         # if temperature is callable, process accordingly
         elif callable(self.temperature):
             arguments = self.temperature.__code__.co_varnames
-            if "t" in arguments and "x" not in arguments and "T" not in arguments:
+            if "t" in arguments and "x" not in arguments:
                 if not isinstance(self.temperature(t=float(self.t)), (float, int)):
                     raise ValueError(
                         f"self.temperature should return a float or an int, not {type(self.temperature(t=float(self.t)))} "

--- a/festim/hydrogen_transport_problem.py
+++ b/festim/hydrogen_transport_problem.py
@@ -3,7 +3,6 @@ from dolfinx.nls.petsc import NewtonSolver
 from dolfinx.io import XDMFFile
 import basix
 import ufl
-from ufl.core.operator import Operator
 from mpi4py import MPI
 from dolfinx.fem import Function, form, assemble_scalar
 from dolfinx.mesh import meshtags

--- a/festim/hydrogen_transport_problem.py
+++ b/festim/hydrogen_transport_problem.py
@@ -197,8 +197,10 @@ class HydrogenTransportProblem:
         elif callable(self.temperature):
             arguments = self.temperature.__code__.co_varnames
             if "t" in arguments and "x" not in arguments and "T" not in arguments:
-                if isinstance(self.temperature(t=float(self.t)), Operator):
-                    raise ValueError("wrong type for temperature")
+                if not isinstance(self.temperature(t=float(self.t)), (float, int)):
+                    raise ValueError(
+                        f"self.temperature should return a float or an int, not {type(self.temperature(t=float(self.t)))} "
+                    )
                 # only t is an argument
                 self.temperature_fenics = F.as_fenics_constant(
                     mesh=self.mesh.mesh, value=self.temperature(t=float(self.t))

--- a/test/test_dirichlet_bc.py
+++ b/test/test_dirichlet_bc.py
@@ -226,6 +226,7 @@ def test_callable_x_only():
         lambda x, t: 1.0 + x[0] + t,
         lambda x, t, T: 1.0 + x[0] + t + T,
         lambda x, t: ufl.conditional(ufl.lt(t, 1.0), 100.0 + x[0], 0.0),
+        lambda t: 100.0 if t < 1 else 0.0,
     ],
 )
 def test_integration_with_HTransportProblem(value):

--- a/test/test_dirichlet_bc.py
+++ b/test/test_dirichlet_bc.py
@@ -304,7 +304,9 @@ def test_define_value_error_if_ufl_conditional_t_only(value):
 
     t = fem.Constant(mesh, 0.0)
 
-    with pytest.raises(ValueError, match="wrong type for temperature"):
+    with pytest.raises(
+        ValueError, match="self.value should return a float or an int, not "
+    ):
         bc.create_value(mesh=mesh, function_space=None, temperature=None, t=t)
 
 

--- a/test/test_dirichlet_bc.py
+++ b/test/test_dirichlet_bc.py
@@ -284,6 +284,30 @@ def test_integration_with_HTransportProblem(value):
     assert np.isclose(computed_value, expected_value)
 
 
+@pytest.mark.parametrize(
+    "value",
+    [
+        lambda t: ufl.conditional(ufl.lt(t, 1.0), 1, 2),
+        lambda t: 1 + ufl.conditional(ufl.lt(t, 1.0), 1, 2.0),
+        lambda t: 2 * ufl.conditional(ufl.lt(t, 1.0), 1, 2.0),
+        lambda t: 2 / ufl.conditional(ufl.lt(t, 1.0), 1, 2.0),
+    ],
+)
+def test_define_value_error_if_ufl_conditional_t_only(value):
+    """Test that a ValueError is raised when the value attribute is a callable
+    of t only and contains a ufl conditional"""
+
+    subdomain = F.SurfaceSubdomain1D(1, x=1)
+    species = F.Species("test")
+
+    bc = F.DirichletBC(subdomain, value, species)
+
+    t = fem.Constant(mesh, 0.0)
+
+    with pytest.raises(ValueError, match="wrong type for temperature"):
+        bc.create_value(mesh=mesh, function_space=None, temperature=None, t=t)
+
+
 def test_species_predefined():
     """Test a ValueError is raised when the species defined in the boundary
     condition is not predefined in the model"""

--- a/test/test_h_transport_problem.py
+++ b/test/test_h_transport_problem.py
@@ -99,6 +99,27 @@ def test_define_temperature(input, expected_type):
     assert isinstance(my_model.temperature_fenics, expected_type)
 
 
+@pytest.mark.parametrize(
+    "input",
+    [
+        lambda t: ufl.conditional(ufl.lt(t, 1.0), 1, 2),
+        lambda t: 1 + ufl.conditional(ufl.lt(t, 1.0), 1, 2.0),
+        lambda t: 2 * ufl.conditional(ufl.lt(t, 1.0), 1, 2.0),
+        lambda t: 2 / ufl.conditional(ufl.lt(t, 1.0), 1, 2.0),
+    ],
+)
+def test_define_temperature_error_if_ufl_conditional_t_only(input):
+    """Test that a ValueError is raised when the temperature attribute is a callable
+    of t only and contains a ufl conditional"""
+    my_model = F.HydrogenTransportProblem(mesh=test_mesh)
+    my_model.t = fem.Constant(test_mesh.mesh, 0.0)
+
+    my_model.temperature = input
+
+    with pytest.raises(ValueError, match="wrong type for temperature"):
+        my_model.define_temperature()
+
+
 def test_iterate():
     """Test that the iterate method updates the solution and time correctly"""
     # BUILD

--- a/test/test_h_transport_problem.py
+++ b/test/test_h_transport_problem.py
@@ -116,7 +116,9 @@ def test_define_temperature_error_if_ufl_conditional_t_only(input):
 
     my_model.temperature = input
 
-    with pytest.raises(ValueError, match="wrong type for temperature"):
+    with pytest.raises(
+        ValueError, match="self.temperature should return a float or an int, not "
+    ):
         my_model.define_temperature()
 
 

--- a/test/test_h_transport_problem.py
+++ b/test/test_h_transport_problem.py
@@ -4,7 +4,6 @@ import mpi4py.MPI as MPI
 import dolfinx.mesh
 from dolfinx import fem, nls
 import ufl
-from ufl.conditional import Conditional
 import numpy as np
 import pytest
 

--- a/test/test_h_transport_problem.py
+++ b/test/test_h_transport_problem.py
@@ -4,6 +4,7 @@ import mpi4py.MPI as MPI
 import dolfinx.mesh
 from dolfinx import fem, nls
 import ufl
+from ufl.conditional import Conditional
 import numpy as np
 import pytest
 
@@ -77,6 +78,7 @@ def test_define_temperature_value_error_raised():
         (lambda x: 1.0 + x[0], fem.Function),
         (lambda x, t: 1.0 + x[0] + t, fem.Function),
         (lambda x, t: ufl.conditional(ufl.lt(t, 1.0), 100.0 + x[0], 0.0), fem.Function),
+        (lambda t: 100.0 if t < 1 else 0.0, fem.Constant),
     ],
 )
 def test_define_temperature(input, expected_type):


### PR DESCRIPTION
## Proposed changes

Linked to #626 

This PR adds a type check when converting temperature and DirichletBC values to a dolfinx object.
If the value is a function of `t` only, and the user used `ufl.conditional` ( _ie_ the type of the returned object is not a float or int) then an error is raised.

## Types of changes

What types of changes does your code introduce to FESTIM?
<!--Put an `x` in the boxes that apply-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

<!--Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.-->

- [x] Black formatted
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
