### PR TITLE
Fix build documentation

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -4,10 +4,10 @@ channels:
   - defaults
 dependencies:
   - fenics
+  - matplotlib==3.7.1
   - pip>=20.1
   - pip:
     - sympy
     - sphinx_book_theme==1.0.1
     - sphinx==6.2.1
     - sphinx-design==0.4.1
-    - matplotlib==3.7.1


### PR DESCRIPTION
## Proposed changes

I've noticed in #628 the documentation build started failing.

This is an attempt at fixing it with the same strategy used in #592, installing matplotlib with conda instead of pip.
