### PR TITLE
typo in F.Source

### DIFF
--- a/festim/source.py
+++ b/festim/source.py
@@ -40,8 +40,6 @@ class Source:
         self.species = species
 
         self.value_fenics = None
-        self.species_festim = None
-        self.volume_festim = None
         self.source_expr = None
 
     @property


### PR DESCRIPTION
Just noticed there was this left in from the sources PR and it can be removed as the attributes are not used